### PR TITLE
Minor typo corrections

### DIFF
--- a/terraform/centralized_outbound/main.tf
+++ b/terraform/centralized_outbound/main.tf
@@ -43,9 +43,9 @@ resource "aws_networkmanager_core_network_policy_attachment" "core_network_polic
   policy_document = local.core_network_policy
 
   depends_on = [
-    module.ireland_inspecion,
-    module.nvirginia_inspecion,
-    module.sydney_inspecion
+    module.ireland_inspection_vpc,
+    module.nvirginia_inspection_vpc,
+    module.sydney_inspection_vpc
   ]
 }
 
@@ -84,7 +84,7 @@ module "ireland_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "ireland_inspecion" {
+module "ireland_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awsireland }
@@ -175,7 +175,7 @@ module "nvirginia_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "nvirginia_inspecion" {
+module "nvirginia_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awsnvirginia }
@@ -266,7 +266,7 @@ module "sydney_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "sydney_inspecion" {
+module "sydney_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awssydney }

--- a/terraform/east_west/main.tf
+++ b/terraform/east_west/main.tf
@@ -43,9 +43,9 @@ resource "aws_networkmanager_core_network_policy_attachment" "core_network_polic
   policy_document = local.core_network_policy
 
   depends_on = [
-    module.ireland_inspecion,
-    module.nvirginia_inspecion,
-    module.sydney_inspecion
+    module.ireland_inspection_vpc,
+    module.nvirginia_inspection_vpc,
+    module.sydney_inspection_vpc
   ]
 }
 
@@ -84,7 +84,7 @@ module "ireland_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "ireland_inspecion" {
+module "ireland_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awsireland }
@@ -173,7 +173,7 @@ module "nvirginia_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "nvirginia_inspecion" {
+module "nvirginia_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awsnvirginia }
@@ -262,7 +262,7 @@ module "sydney_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "sydney_inspecion" {
+module "sydney_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awssydney }

--- a/terraform/east_west_tgw_spoke_vpcs/main.tf
+++ b/terraform/east_west_tgw_spoke_vpcs/main.tf
@@ -43,9 +43,9 @@ resource "aws_networkmanager_core_network_policy_attachment" "core_network_polic
   policy_document = local.core_network_policy
 
   depends_on = [
-    module.ireland_inspecion,
-    module.nvirginia_inspecion,
-    module.sydney_inspecion,
+    module.ireland_inspection_vpc,
+    module.nvirginia_inspection_vpc,
+    module.sydney_inspection_vpc,
     module.ireland_transit_gateway,
     module.nvirginia_transit_gateway,
     module.sydney_transit_gateway
@@ -85,7 +85,7 @@ module "ireland_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "ireland_inspecion" {
+module "ireland_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awsireland }
@@ -178,7 +178,7 @@ module "nvirginia_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "nvirginia_inspecion" {
+module "nvirginia_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awsnvirginia }
@@ -271,7 +271,7 @@ module "sydney_spoke_vpcs" {
 }
 
 # Inspection VPC - definition in variables.tf
-module "sydney_inspecion" {
+module "sydney_inspection_vpc" {
   source    = "aws-ia/cloudwan/aws"
   version   = "3.2.0"
   providers = { aws = aws.awssydney }

--- a/terraform/east_west_tgw_spoke_vpcs/outputs.tf
+++ b/terraform/east_west_tgw_spoke_vpcs/outputs.tf
@@ -16,15 +16,15 @@ output "vpcs" {
   value = {
     ireland = {
       spokes     = { for k, v in module.ireland_spoke_vpcs : k => v.vpc_attributes.id }
-      inspection = module.ireland_inspection_vpc.vpc_attributes.id
+      inspection = module.ireland_inspection_vpc.central_vpcs.inspection.vpc_attributes.id
     }
     nvirginia = {
       spokes     = { for k, v in module.nvirginia_spoke_vpcs : k => v.vpc_attributes.id }
-      inspection = module.nvirginia_inspection_vpc.vpc_attributes.id
+      inspection = module.nvirginia_inspection_vpc.central_vpcs.inspection.vpc_attributes.id
     }
     sydney = {
       spokes     = { for k, v in module.sydney_spoke_vpcs : k => v.vpc_attributes.id }
-      inspection = module.sydney_inspection_vpc.vpc_attributes.id
+      inspection = module.sydney_inspection_vpc.central_vpcs.inspection.vpc_attributes.id
     }
   }
 }


### PR DESCRIPTION
*Description of changes:*
Corrected typos in some occurrences of 'inspection' and kept the nomenclature of <region>_inspection vs <region>_inspection_vpc.

Made the appropriate chages in each outputs.tf file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
